### PR TITLE
Safer reactive coupling

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -38,17 +38,25 @@ var peerStateEvents = [
 module.exports = function(pc, targetId, signaller, parentBus) {
   var monitor = mbus('', parentBus);
   var state;
+  var connectionState;
 
   function checkState() {
-    var newState = getMappedState(pc.iceConnectionState);
+    var newConnectionState = pc.iceConnectionState;
+    var newState = getMappedState(newConnectionState);
 
     // flag the we had a state change
     monitor('statechange', pc, newState);
+    monitor('connectionstatechange', pc, newConnectionState);
 
     // if the active state has changed, then send the appopriate message
     if (state !== newState) {
       monitor(newState);
       state = newState;
+    }
+
+    if (connectionState !== newConnectionState) {
+      monitor('connectionstate:' + newConnectionState);
+      connectionState = newConnectionState;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cog": "^1.0.0",
     "mbus": "^2.0.0",
     "rtc-core": "^4.0.0",
-    "rtc-taskqueue": "^2.2.0",
+    "rtc-taskqueue": "^2.9.0",
     "whisk": "^1.1.0"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "hint": "jshint *.js",
-    "test": "browserify test/all.js | broth start-$BROWSER | tap-spec",
+    "test": "browserify test/all.js | broth start | tap-spec",
     "gendocs": "gendocs > README.md"
   },
   "main": "index.js",


### PR DESCRIPTION
Handles reactive coupling in such a way as to prevent the potential for multiple offer->answer sequences to be operating in parallel which could cause connection setups to fail (typically with an error like `could not set remote description. STATE_INPROGRESS`, or some such).

If a request for renegotiation of the PeerConnection arrives will the connection is currently exchaning offers + answers will raise the `negotiationRequired` flag, which will then result on a renegotiation occurring (when `reactive` is indicated) after the offer->answer steps are completed.