### PR TITLE
Add fallback handling of closed states

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -39,6 +39,7 @@ module.exports = function(pc, targetId, signaller, parentBus) {
   var monitor = mbus('', parentBus);
   var state;
   var connectionState;
+  var isClosed = false;
 
   function checkState() {
     var newConnectionState = pc.iceConnectionState;
@@ -52,6 +53,11 @@ module.exports = function(pc, targetId, signaller, parentBus) {
     if (state !== newState) {
       monitor(newState);
       state = newState;
+
+      // As Firefox does not always support `onclose`, handle closed state changes
+      if (state === 'closed' && !isClosed) {
+        handleClose();
+      }
     }
 
     if (connectionState !== newConnectionState) {
@@ -61,6 +67,7 @@ module.exports = function(pc, targetId, signaller, parentBus) {
   }
 
   function handleClose() {
+    isClosed = true;
     monitor('closed');
   }
 

--- a/monitor.js
+++ b/monitor.js
@@ -53,16 +53,17 @@ module.exports = function(pc, targetId, signaller, parentBus) {
     if (state !== newState) {
       monitor(newState);
       state = newState;
-
-      // As Firefox does not always support `onclose`, handle closed state changes
-      if (state === 'closed' && !isClosed) {
-        handleClose();
-      }
     }
 
     if (connectionState !== newConnectionState) {
       monitor('connectionstate:' + newConnectionState);
       connectionState = newConnectionState;
+    }
+
+    // As Firefox does not always support `onclose`, if the state is closed
+    // and we haven't already handled the close, do so now
+    if (newState === 'closed' && !isClosed) {
+      handleClose();
     }
   }
 


### PR DESCRIPTION
Fire the `handleClose` method if the closed connection state is encountered, and `onclose` has not been already called.