### PR TITLE
Adds in a `ready` message, that indicates peer readiness for coupling

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -69,6 +69,10 @@ function couple(pc, targetId, signaller, opts) {
   var readyInterval = (opts || {}).readyInterval || 100;
   var readyTimer;
 
+  // Failure timeout
+  var failTimeout = (opts || {}).failTimeout || 30000;
+  var failTimer;
+
   // initilaise the negotiation helpers
   var isMaster = signaller.isMaster(targetId);
 
@@ -311,6 +315,16 @@ function couple(pc, targetId, signaller, opts) {
   }
   checkReady();
   debug('ready for coupling');
+
+  // If we fail to connect within the given timeframe, trigger a failure
+  failTimer = setTimeout(function() {
+    mon('failed');
+    decouple();
+  }, failTimeout);
+
+  mon.once('connected', function() {
+    clearTimeout(failTimer);
+  });
 
   return mon;
 }

--- a/couple.js
+++ b/couple.js
@@ -63,6 +63,12 @@ function couple(pc, targetId, signaller, opts) {
   var disconnectTimeout = (opts || {}).disconnectTimeout || 10000;
   var disconnectTimer;
 
+  // Target ready indicates that the target peer has indicated it is
+  // ready to begin coupling
+  var targetReady = false;
+  var readyInterval = (opts || {}).readyInterval || 100;
+  var readyTimer;
+
   // initilaise the negotiation helpers
   var isMaster = signaller.isMaster(targetId);
 
@@ -72,6 +78,12 @@ function couple(pc, targetId, signaller, opts) {
   var negotiationRequired = false;
 
   var createOrRequestOffer = throttle(function() {
+    if (!targetReady) {
+      debug('Target not yet ready for offer');
+      return emit.once('target.ready', createOrRequestOffer);
+    }
+
+    debug('createOrRequestOffer');
     // If this is not the master, always send the negotiate request
     // Redundant requests are eliminated on the master side
     if (! isMaster) {
@@ -101,11 +113,13 @@ function couple(pc, targetId, signaller, opts) {
     signaller.removeListener('sdp', handleSdp);
     signaller.removeListener('candidate', handleCandidate);
     signaller.removeListener('negotiate', handleNegotiateRequest);
+    signaller.removeListener('ready', handleReady);
 
     // remove listeners (version >= 5)
     signaller.removeListener('message:sdp', handleSdp);
     signaller.removeListener('message:candidate', handleCandidate);
     signaller.removeListener('message:negotiate', handleNegotiateRequest);
+    signaller.removeListener('message:ready', handleReady);
   }
 
   function handleCandidate(data, src) {
@@ -143,6 +157,15 @@ function couple(pc, targetId, signaller, opts) {
         if (negotiationRequired) createOrRequestOffer();
       }
     });
+  }
+
+  function handleReady(src) {
+    if (targetReady || !src || src.id !== targetId) {
+      return;
+    }
+    debug('target is ready for coupling');
+    targetReady = true;
+    emit('target.ready');
   }
 
   function handleConnectionClose() {
@@ -255,11 +278,13 @@ function couple(pc, targetId, signaller, opts) {
   signaller.on('sdp', handleSdp);
   signaller.on('candidate', handleCandidate);
   signaller.on('endofcandidates', handleLastCandidate);
+  signaller.on('ready', handleReady);
 
   // listeners (signaller >= 5)
   signaller.on('message:sdp', handleSdp);
   signaller.on('message:candidate', handleCandidate);
   signaller.on('message:endofcandidates', handleLastCandidate);
+  signaller.on('message:ready', handleReady);
 
   // if this is a master connection, listen for negotiate events
   if (isMaster) {
@@ -273,6 +298,19 @@ function couple(pc, targetId, signaller, opts) {
 
   // patch in the create offer functions
   mon.createOffer = createOrRequestOffer;
+
+  // A heavy handed approach to ensuring readiness across the coupling
+  // peers. Will periodically send the `ready` message to the target peer
+  // until the target peer has acknowledged that it also is ready - at which
+  // point the offer can be sent
+  function checkReady() {
+    clearTimeout(readyTimer);
+    if (targetReady) return;
+    signaller.to(targetId).send('/ready');
+    readyTimer = setTimeout(checkReady, readyInterval);
+  }
+  checkReady();
+  debug('ready for coupling');
 
   return mon;
 }


### PR DESCRIPTION
This fixes an issue that was exacerbated with the introduction of asynchronous generation of ICE candidates - where a connection would fail to setup, and hang due to the initial offer SDP not being received due to `couple()` not yet being called and the `sdp` event listeners not yet being registered.

As such, the receiving peer would receive the SDP offer, and not do anything, then would just wait for the offer to arrive.

This PR introduces the concept of coupling _readiness_. Each peer is required to notify the other peer of it's readiness using the `ready` message and only once both peers are ready will the connection setup be started. Peers will rebroadcast the `ready` message periodically until the target peer has sent it's own ready message.