### PR TITLE
Add failing and recovered tests

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -261,7 +261,7 @@ function couple(pc, targetId, signaller, opts) {
   }
 
   function resetDisconnectTimer() {
-    var recovered = !!disconnectTimer;
+    var recovered = !!disconnectTimer && pc.iceConnectionState !== 'closed';
     mon.off('statechange', handleDisconnectAbort);
 
     // clear the disconnect timer

--- a/couple.js
+++ b/couple.js
@@ -261,7 +261,7 @@ function couple(pc, targetId, signaller, opts) {
   }
 
   function resetDisconnectTimer() {
-    var recovered = !!disconnectTimer && pc.iceConnectionState !== 'closed';
+    var recovered = !!disconnectTimer && CLOSED_STATES.indexOf(pc.iceConnectionState) === -1;
     mon.off('statechange', handleDisconnectAbort);
 
     // clear the disconnect timer

--- a/couple.js
+++ b/couple.js
@@ -187,6 +187,7 @@ function couple(pc, targetId, signaller, opts) {
     }, disconnectTimeout);
 
     mon.on('statechange', handleDisconnectAbort);
+    mon('failing');
   }
 
   function handleDisconnectAbort() {
@@ -259,11 +260,18 @@ function couple(pc, targetId, signaller, opts) {
   }
 
   function resetDisconnectTimer() {
+    var recovered = !!disconnectTimer;
     mon.off('statechange', handleDisconnectAbort);
 
     // clear the disconnect timer
     debug('reset disconnect timer, state: ' + pc.iceConnectionState);
     clearTimeout(disconnectTimer);
+    disconnectTimer = undefined;
+
+    // Trigger the recovered event if this is a recovery
+    if (recovered) {
+      mon('recovered');
+    }
   }
 
   // when regotiation is needed look for the peer

--- a/couple.js
+++ b/couple.js
@@ -83,7 +83,7 @@ function couple(pc, targetId, signaller, opts) {
 
   var createOrRequestOffer = throttle(function() {
     if (!targetReady) {
-      debug('Target not yet ready for offer');
+      debug('[' + signaller.id + '] ' + targetId + ' not yet ready for offer');
       return emit.once('target.ready', createOrRequestOffer);
     }
 
@@ -167,7 +167,7 @@ function couple(pc, targetId, signaller, opts) {
     if (targetReady || !src || src.id !== targetId) {
       return;
     }
-    debug('target is ready for coupling');
+    debug('[' + signaller.id + '] ' + targetId + ' is ready for coupling');
     targetReady = true;
     emit('target.ready');
   }
@@ -183,6 +183,7 @@ function couple(pc, targetId, signaller, opts) {
     // start the disconnect timer
     disconnectTimer = setTimeout(function() {
       debug('manually closing connection after disconnect timeout');
+      mon('failed');
       cleanup(pc);
     }, disconnectTimeout);
 
@@ -327,7 +328,7 @@ function couple(pc, targetId, signaller, opts) {
     readyTimer = setTimeout(checkReady, readyInterval);
   }
   checkReady();
-  debug('ready for coupling');
+  debug('[' + signaller.id + '] ready for coupling to ' + targetId);
 
   // If we fail to connect within the given timeframe, trigger a failure
   failTimer = setTimeout(function() {


### PR DESCRIPTION
To allow for better notification of when a connection encounters difficulty, when a disconnect timer is triggered, also emit a `failing` event.

If the connection recovers, emit a `recovered` event