### PR TITLE
Add the ability to `abort` an in-progress couple

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -340,6 +340,17 @@ function couple(pc, targetId, signaller, opts) {
     clearTimeout(failTimer);
   });
 
+  /**
+    Aborts the coupling process
+   **/
+  mon.abort = function() {
+    if (failTimer) {
+      clearTimeout(failTimer);
+    }
+    decouple();
+    mon('aborted');
+  };
+
   return mon;
 }
 


### PR DESCRIPTION
Adds in the ability to cancel an in progress coupling of a connection by calling the `monitor.abort()` after `couple`.

Aborting a connection follows the same mechanism as for failing a connection, but emits an `aborted` event and can be called manually.

For peers who were attempting to couple to a peer when that peer aborts, they not emit an `aborted` event, but will rather timeout using the timeout mechanism (unless they are themselves manually aborted)