### PR TITLE
Allow clients to request ability to create offers

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -130,7 +130,7 @@ function couple(pc, targetId, signaller, opts) {
 
     // stop the monitor
 //     mon.removeAllListeners();
-    mon.stop();
+    mon.close();
 
     // cleanup the peerconnection
     cleanup(pc);
@@ -140,12 +140,15 @@ function couple(pc, targetId, signaller, opts) {
     signaller.removeListener('candidate', handleCandidate);
     signaller.removeListener('negotiate', handleNegotiateRequest);
     signaller.removeListener('ready', handleReady);
+    signaller.removeListener('requestoffer', handleRequestOffer);
 
     // remove listeners (version >= 5)
     signaller.removeListener('message:sdp', handleSdp);
     signaller.removeListener('message:candidate', handleCandidate);
     signaller.removeListener('message:negotiate', handleNegotiateRequest);
     signaller.removeListener('message:ready', handleReady);
+    signaller.removeListener('message:requestoffer', handleRequestOffer);
+
   }
 
   function handleCandidate(data, src) {
@@ -415,6 +418,8 @@ function couple(pc, targetId, signaller, opts) {
       createOrRequestOffer();
     }
   });
+
+  mon.stop = decouple;
 
   /**
     Aborts the coupling process

--- a/couple.js
+++ b/couple.js
@@ -124,6 +124,10 @@ function couple(pc, targetId, signaller, opts) {
     // Redundant requests are eliminated on the master side
     if (! isMaster) {
       debug('[' + signaller.id + '] ' + 'Requesting negotiation from ' + targetId + ' (requesting offerer? ' + renegotiateRequired + ')');
+      // Due to https://bugs.chromium.org/p/webrtc/issues/detail?id=2782 which involves incompatibilities between
+      // Chrome and Firefox created offers by default client offers are disabled to ensure that all offers are coming
+      // from the same source. By passing `allowReactiveInterop` you can reallow this, then use the `filtersdp` option
+      // to provide a munged SDP that might be able to work
       return signaller.to(targetId).send('/negotiate', {
         requestOfferer: (allowReactiveInterop || !interoperating) && renegotiateRequired
       });

--- a/couple.js
+++ b/couple.js
@@ -73,6 +73,9 @@ function couple(pc, targetId, signaller, opts) {
   var failTimeout = (opts || {}).failTimeout || 30000;
   var failTimer;
 
+  // Request offer timer
+  var requestOfferTimer;
+
   // initilaise the negotiation helpers
   var isMaster = signaller.isMaster(targetId);
 
@@ -80,6 +83,31 @@ function couple(pc, targetId, signaller, opts) {
   var q = queue(pc, opts);
   var coupling = false;
   var negotiationRequired = false;
+  var renegotiateRequired = false;
+  var creatingOffer = false;
+
+  /**
+    Indicates whether this peer connection is in a state where it is able to have new offers created
+   **/
+  function isReadyForOffer() {
+    return !coupling && pc.signalingState === 'stable';
+  }
+
+  function createOffer() {
+    // If coupling is already in progress, return
+    if (!isReadyForOffer()) return;
+
+    debug('[' + signaller.id + '] ' + 'Creating new offer for connection to ' + targetId);
+    // Otherwise, create the offer
+    coupling = true;
+    creatingOffer = true;
+    negotiationRequired = false;
+    q.createOffer().then(function() {
+      creatingOffer = false;
+    }).catch(function() {
+      creatingOffer = false;
+    });
+  }
 
   var createOrRequestOffer = throttle(function() {
     if (!targetReady) {
@@ -87,20 +115,14 @@ function couple(pc, targetId, signaller, opts) {
       return emit.once('target.ready', createOrRequestOffer);
     }
 
-    debug('createOrRequestOffer');
     // If this is not the master, always send the negotiate request
     // Redundant requests are eliminated on the master side
     if (! isMaster) {
-      return signaller.to(targetId).send('/negotiate');
+      debug('[' + signaller.id + '] ' + 'Requesting negotiation from ' + targetId + ' (requesting offerer? ' + renegotiateRequired + ')');
+      return signaller.to(targetId).send('/negotiate', { requestOfferer: renegotiateRequired });
     }
 
-    // If coupling is already in progress, return
-    if (coupling) return;
-
-    // Otherwise, create the offer
-    coupling = true;
-    negotiationRequired = false;
-    q.createOffer();
+    return createOffer();
   }, 100, { leading: false });
 
   function decouple() {
@@ -152,13 +174,13 @@ function couple(pc, targetId, signaller, opts) {
     // renegotiating prior to the iceConnectionState "completed" state
     q.setRemoteDescription(sdp).then(function() {
 
-      // If this is the master, then we can assume that this description was the answer
-      // and assume that coupling (offer -> answer) process is complete, so we can
-      // now renegotiate without threat of interference
-      if (isMaster) {
+      // If this is the peer that is coupling, and we have received the answer so we can
+      // and assume that coupling (offer -> answer) process is complete, so we can clear the coupling flag
+      if (coupling && sdp.type === 'answer') {
         debug('coupling complete, can now trigger any pending renegotiations');
         coupling = false;
-        if (negotiationRequired) createOrRequestOffer();
+        // If this is the master and negotiation is required, process the next offers
+        if (isMaster && negotiationRequired) createOrRequestOffer();
       }
     });
   }
@@ -247,16 +269,46 @@ function couple(pc, targetId, signaller, opts) {
     }
   }
 
-  function handleNegotiateRequest(src) {
-    if (src.id === targetId) {
-      emit('negotiate.request', src.id);
-      requestNegotiation();
+
+  /**
+    This allows the master to request the client to send an offer
+   **/
+  function requestOfferFromClient() {
+    if (requestOfferTimer) clearTimeout(requestOfferTimer);
+    if (pc.signalingState === 'closed') return;
+
+    // Check if we are ready for a new offer, otherwise delay
+    if (!isReadyForOffer()) {
+      debug('[' + signaller.id + '] negotiation request denied, not in a state to accept new offers [coupling = ' + coupling + ', ' + pc.signalingState + ']');
+      requestOfferTimer = setTimeout(requestOfferFromClient, 500);
+    } else {
+       // Flag as coupling and request the client send the offer
+      debug('[' + signaller.id + '] ' + targetId + ' has requested the ability to create the offer');
+      coupling = true;
+      return signaller.to(targetId).send('/requestoffer');
     }
+  }
+
+  function handleNegotiateRequest(data, src) {
+    debug('[' + signaller.id + '] ' + src.id + ' has requested a negotiation');
+
+    // Sanity check that this is for the target
+    if (!src || src.id !== targetId) return;
+    emit('negotiate.request', src.id, data);
+
+    // Check if the client is requesting the ability to create the offer themselves
+    if (data && data.requestOfferer) {
+      return requestOfferFromClient();
+    }
+
+    // Otherwise, begin the traditional master driven negotiation process
+    requestNegotiation();
   }
 
   function handleRenegotiateRequest() {
     if (!reactive) return;
     emit('negotiate.renegotiate');
+    renegotiateRequired = true;
     requestNegotiation();
   }
 
@@ -273,6 +325,13 @@ function couple(pc, targetId, signaller, opts) {
     if (recovered) {
       mon('recovered');
     }
+  }
+
+  /**
+    Allow clients to send offers
+   **/
+  function handleRequestOffer(src) {
+    return createOffer();
   }
 
   // when regotiation is needed look for the peer
@@ -303,6 +362,9 @@ function couple(pc, targetId, signaller, opts) {
   if (isMaster) {
     signaller.on('negotiate', handleNegotiateRequest);
     signaller.on('message:negotiate', handleNegotiateRequest); // signaller >= 5
+  } else {
+    signaller.on('requestoffer', handleRequestOffer);
+    signaller.on('message:requestoffer', handleRequestOffer);
   }
 
   // when the connection closes, remove event handlers
@@ -338,6 +400,22 @@ function couple(pc, targetId, signaller, opts) {
 
   mon.once('connected', function() {
     clearTimeout(failTimer);
+  });
+
+  mon.on('signalingchange', function(pc, state) {
+    debug('[' + signaller.id + '] signaling state ' + state + ' to ' + targetId);
+  });
+
+  mon.on('signaling:stable', function() {
+    // Check if the coupling process is over
+    // creatingOffer is required due to the delay between the creation of the offer and the signaling
+    // state changing to have-local-offer
+    if (!creatingOffer && coupling) coupling = false;
+
+    // Check if we have any pending negotiations
+    if (negotiationRequired) {
+      createOrRequestOffer();
+    }
   });
 
   /**

--- a/couple.js
+++ b/couple.js
@@ -139,6 +139,12 @@ function couple(pc, targetId, signaller, opts) {
   function decouple() {
     debug('decoupling ' + signaller.id + ' from ' + targetId);
 
+    // Clear any outstanding timers
+    clearTimeout(readyTimer);
+    clearTimeout(disconnectTimer);
+    clearTimeout(requestOfferTimer);
+    clearTimeout(failTimer);
+
     // stop the monitor
 //     mon.removeAllListeners();
     mon.close();
@@ -149,6 +155,7 @@ function couple(pc, targetId, signaller, opts) {
     // remove listeners
     signaller.removeListener('sdp', handleSdp);
     signaller.removeListener('candidate', handleCandidate);
+    signaller.removeListener('endofcandidates', handleLastCandidate);
     signaller.removeListener('negotiate', handleNegotiateRequest);
     signaller.removeListener('ready', handleReady);
     signaller.removeListener('requestoffer', handleRequestOffer);
@@ -156,6 +163,7 @@ function couple(pc, targetId, signaller, opts) {
     // remove listeners (version >= 5)
     signaller.removeListener('message:sdp', handleSdp);
     signaller.removeListener('message:candidate', handleCandidate);
+    signaller.removeListener('message:endofcandidates', handleLastCandidate);
     signaller.removeListener('message:negotiate', handleNegotiateRequest);
     signaller.removeListener('message:ready', handleReady);
     signaller.removeListener('message:requestoffer', handleRequestOffer);

--- a/couple.js
+++ b/couple.js
@@ -332,6 +332,7 @@ function couple(pc, targetId, signaller, opts) {
     Allow clients to send offers
    **/
   function handleRequestOffer(src) {
+    debug('[' + signaller.id + '] ' + targetId + ' has requested that the offer be sent');
     return createOffer();
   }
 

--- a/couple.js
+++ b/couple.js
@@ -178,8 +178,6 @@ function couple(pc, targetId, signaller, opts) {
       // and assume that coupling (offer -> answer) process is complete, so we can clear the coupling flag
       if (coupling && sdp.type === 'answer') {
         debug('coupling complete, can now trigger any pending renegotiations');
-        coupling = false;
-        // If this is the master and negotiation is required, process the next offers
         if (isMaster && negotiationRequired) createOrRequestOffer();
       }
     });

--- a/monitor.js
+++ b/monitor.js
@@ -86,7 +86,7 @@ module.exports = function(pc, targetId, signaller, parentBus) {
     pc['on' + evtName] = checkState;
   });
 
-  monitor.stop = function() {
+  monitor.close = function() {
     pc.onclose = null;
     peerStateEvents.forEach(function(evtName) {
       pc['on' + evtName] = null;


### PR DESCRIPTION
The second take on #47 - this attempts to resolve issues with Firefox renegotiated streams where the client peer is required to create the offer in order to have the stream properly added.

The master peer retains the control over ensuring that concurrent offer->answer flows cannot be started. When a client wants to create an offer, it sends a `/negotiate` message with the payload `{requestOfferer: true}` to the master.

The master when handling the negotiate message will then check this flag, and if set, will request the offer from the client peer when it is next possible.

The rest of the PR is associated logic around ensuring that the master correctly tracks the state of the peer connection offer flow.