### PR TITLE
When client requests offer, only send the offer when requested by the intended target

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -353,7 +353,8 @@ function couple(pc, targetId, signaller, opts) {
     Allow clients to send offers
    **/
   function handleRequestOffer(src) {
-    debug('[' + signaller.id + '] ' + targetId + ' has requested that the offer be sent');
+    if (!src || src.id !== targetId) return;
+    debug('[' + signaller.id + '] ' + targetId + ' has requested that the offer be sent [' + src.id + ']');
     return createOffer();
   }
 


### PR DESCRIPTION
Ensures that the client only creates an offer when it is confirmed that the `/requestoffer` message is from the intended recipient.

This fixes the situation where, when a peer joined an already existing multi-peer call, they could receive a `/requestoffer` message from one peer, and mistakingly send an offer to another peer (who may not have been in the appropriate state to receive it)