### PR TITLE
Garbage collection improvements

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -148,6 +148,11 @@ function couple(pc, targetId, signaller, opts) {
     // stop the monitor
 //     mon.removeAllListeners();
     mon.close();
+    mon = undefined;
+
+    // clean up the task queue
+    q.clear();
+    q = undefined;
 
     // cleanup the peerconnection
     cleanup(pc);
@@ -167,7 +172,6 @@ function couple(pc, targetId, signaller, opts) {
     signaller.removeListener('message:negotiate', handleNegotiateRequest);
     signaller.removeListener('message:ready', handleReady);
     signaller.removeListener('message:requestoffer', handleRequestOffer);
-
   }
 
   function handleCandidate(data, src) {
@@ -228,7 +232,7 @@ function couple(pc, targetId, signaller, opts) {
     disconnectTimer = setTimeout(function() {
       debug('manually closing connection after disconnect timeout');
       mon('failed');
-      cleanup(pc);
+      decouple();
     }, disconnectTimeout);
 
     mon.on('statechange', handleDisconnectAbort);

--- a/monitor.js
+++ b/monitor.js
@@ -77,6 +77,7 @@ module.exports = function(pc, targetId, signaller, parentBus) {
   }
 
   function handleClose() {
+    if (isClosed) return;
     isClosed = true;
     monitor('closed');
   }
@@ -91,9 +92,10 @@ module.exports = function(pc, targetId, signaller, parentBus) {
     peerStateEvents.forEach(function(evtName) {
       pc['on' + evtName] = null;
     });
-  };
 
-  monitor.checkState = checkState;
+    monitor.clear();
+    monitor = undefined;
+  };
 
   // if we haven't been provided a valid peer connection, abort
   if (! pc) {


### PR DESCRIPTION
Currently, when a peer connection is no longer in use, it is not being properly garbage collected. This is partly due to function contexts which contain the peer connection being kept alive by `mbus` instance event listeners.

This changes the teardown procedures for the monitor and task queue to clear any listeners that are waiting on these mbus instances.