### PR TITLE
Adds `destroy` methods to the monitor

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -455,6 +455,12 @@ function couple(pc, targetId, signaller, opts) {
     mon('aborted');
   };
 
+  // Override destroy to clear the task queue as well
+  mon.destroy = function() {
+    mon.clear();
+    q.clear();
+  };
+
   return mon;
 }
 

--- a/monitor.js
+++ b/monitor.js
@@ -95,6 +95,10 @@ module.exports = function(pc, targetId, signaller, parentBus) {
 
   monitor.checkState = checkState;
 
+  monitor.destroy = function() {
+    monitor.clear();
+  };
+
   // if we haven't been provided a valid peer connection, abort
   if (! pc) {
     return monitor;


### PR DESCRIPTION
As an extra precaution, adds `destroy` methods to the monitor that will clean up any outstanding listeners on the `mbus` instances that might prevent successful garbage collection.