### PR TITLE
Fix client ability to request a renegotiation while one is in progress

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -219,7 +219,7 @@ function couple(pc, targetId, signaller, opts) {
         checkIfCouplingComplete();
 
         debug('coupling complete, can now trigger any pending renegotiations');
-        if (isMaster && negotiationRequired) createOrRequestOffer();
+        if (negotiationRequired) createOrRequestOffer();
       }
     });
   }
@@ -320,7 +320,10 @@ function couple(pc, targetId, signaller, opts) {
 
     // Check if we are ready for a new offer, otherwise delay
     if (!isReadyForOffer()) {
-      debug('[' + signaller.id + '] negotiation request denied, not in a state to accept new offers [coupling = ' + coupling + ', ' + pc.signalingState + ']');
+      debug('[' + signaller.id + '] negotiation request denied, not in a state to accept new offers [coupling = ' + coupling + ', creatingOffer = ' + creatingOffer + ', awaitingAnswer = ' + awaitingAnswer + ', ' + pc.signalingState + ']');
+      // Do a check to see if the coupling is complete
+      checkIfCouplingComplete();
+      // Do a recheck of the request
       requestOfferTimer = setTimeout(requestOfferFromClient, 500);
     } else {
        // Flag as coupling and request the client send the offer


### PR DESCRIPTION
This fixes an edge case that presents itself in the following situation:

1. A negotiation is currently in progress between two peers (such as adding an additional track to an existing peer connection)
2. While the offer/answer SDPs are being exchanged, the client peer wants to perform a new renegotiation (ie. a track has been added/removed).
3. Once the existing coupling was completed, no new negotiation was performed.