### PR TITLE
Expose ability to manually trigger a renegotiation

### DIFF
--- a/couple.js
+++ b/couple.js
@@ -478,6 +478,11 @@ function couple(pc, targetId, signaller, opts) {
   mon.stop = decouple;
 
   /**
+    Allows for manually triggering a renegotiation
+   */
+  mon.requestRenegotiation = handleRenegotiateRequest;
+
+  /**
     Aborts the coupling process
    **/
   mon.abort = function() {


### PR DESCRIPTION
A simply update to add `requestRenegotiation` to the exposed monitor object.

This allows for a negotiation to be requested manually.